### PR TITLE
Hinzufügen von Anti-Pattern beim Zugang durch automatisierte Browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Alles hier ist noch in Diskussion – falls ihr noch Ideen dazu habt, helft gern
 * Zugang
   * [Noch ein Daten-Portal erstellen](patterns/datenportal.md)
   * [User-Agents ausschließen](patterns/useragents.md)
+  * [Automatisierte Browser ausschließen](patterns/automatisierung.md)
   * [Jede neue Version unter neuer Adresse veröffentlichen](patterns/versionierung.md)
   * [Verwende für Features keine, nur Dir bekannte, am besten ständig wechselnde IDs, die es unmöglich machen, sie mit Daten anderer Quellen zu verknüpfen](patterns/ids.md)
   * [Erfordere eine Registrierung zum Abruf der ‚offenen Daten‘](patterns/registrierung.md)

--- a/patterns/automatisierung.md
+++ b/patterns/automatisierung.md
@@ -1,0 +1,29 @@
+### Automatisierte Browser ausschließen
+
+#### Kurzbezeichnung
+Automaten-Diskriminierung
+
+#### Kategorie
+Zugang
+
+#### Ungute Lösung
+Filtere anfragende Clients anhand dem `navigator.webdriver` Wert aus
+
+#### Negative Konsequenzen
+Bei (manuellen) Datensatz-Abrufen aus dem Browser scheint der Abruf zu funktionieren, automatisierte schlagen (z.B. indem javascript nicht lädt) fehl
+
+#### Ursprüngliches Problem
+Mutmaßlich Maßnahme zur Blockierung  von Massenanfragen naiv abfragender Clients 
+
+#### WorkAround
+Der einfachste Weg ist vor dem Aufruf der Seite den `navigator.webdriver` zu entfernen im aktiven Tab.
+
+#### Empfohlene Lösung
+z.B. Rate-limits in Abhängigkeit der IP festlegen 
+
+#### Beispiele
+
+#### Cartoon/Visualisierung
+?
+
+#### Weitere Informationen


### PR DESCRIPTION
Moin!

Ich denke dies sollte ein weiteres Anti Pattern sein, dass hand in hand mit dem User Agent blockieren bei zum Beispiel curl geht. Browser können Automatisiert werden, wodurch man diese durch skripte bedienen kann. Hierbei wird die `navigator.webdriver` flag auf true gesetzt. Es gibt vereinzelt (z.B.: Facebook) Seiten, die dies aktiv verbieten. Für OpenData sollte dies nicht gemacht werden und ein Hinweis bevor es dazu kommt denke ich ist angebracht, da bestimmt früher oder später jemand meint dies tun zu müssen.